### PR TITLE
Update build-angular deps to 12.1 to resolve security vulnerabilities

### DIFF
--- a/demos/angular-cli-with-library/package.json
+++ b/demos/angular-cli-with-library/package.json
@@ -25,7 +25,7 @@
     "zone.js": "~0.8.26"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.8.0",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@angular-devkit/build-ng-packagr": "~0.8.0",
     "@angular/cli": "~6.2.3",
     "@angular/compiler-cli": "^7.1.1",

--- a/demos/angular-cli-without-library/package.json
+++ b/demos/angular-cli-without-library/package.json
@@ -26,7 +26,7 @@
     "zone.js": "~0.8.26"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.8.0",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@angular-devkit/build-ng-packagr": "~0.8.0",
     "@angular/cli": "~6.2.3",
     "@angular/compiler-cli": "^7.1.1",

--- a/demos/ext-angular-dashboard/package.json
+++ b/demos/ext-angular-dashboard/package.json
@@ -23,7 +23,7 @@
     "@sencha/ext-pivot": "~6.6.0",
     "@sencha/ext-pivot-d3": "~6.6.0",
     "@sencha/ext-ux": "~6.6.0",
-    
+
     "@sencha/ext-modern-theme-material": "~6.6.0",
 
     "d3": "4.5.0",
@@ -45,7 +45,7 @@
     "@angular-builders/dev-server":"^7.0.0",
     "@sencha/ext-angular-webpack-plugin": "~6.7.0",
 
-    "@angular-devkit/build-angular": "~0.10.5",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@angular/cli": "~7.0.5",
     "@angular/compiler-cli": "^7.0.3",
     "@angular/language-service": "^7.0.3",

--- a/demos/ext-angular-router/package.json
+++ b/demos/ext-angular-router/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@angular-builders/custom-webpack": "^7.0.0",
     "@angular-builders/dev-server": "^7.0.0",
-    "@angular-devkit/build-angular": "~0.11.0",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@sencha/ext-angular-webpack-plugin": "6.7.0",
     "html-webpack-plugin": "^3.2.0",
     "sass-loader":"^7.1.0",

--- a/packages/ext-angular-dashboard/package.json
+++ b/packages/ext-angular-dashboard/package.json
@@ -45,7 +45,7 @@
     "@angular-builders/dev-server":"^7.0.0",
     "@sencha/ext-angular-webpack-plugin": "~6.7.0",
 
-    "@angular-devkit/build-angular": "~0.10.5",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@angular/cli": "~7.0.5",
     "@angular/compiler-cli": "^7.0.3",
     "@angular/language-service": "^7.0.3",

--- a/packages/ext-angular-demo/package.json
+++ b/packages/ext-angular-demo/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@angular-builders/custom-webpack": "^7.0.0",
     "@angular-builders/dev-server": "^7.0.0",
-    "@angular-devkit/build-angular": "~0.11.3",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@sencha/ext-angular-webpack-plugin": "6.7.0",
     "html-webpack-plugin": "^3.2.0",
     "sass-loader":"^7.1.0",

--- a/packages/ext-angular-modern-boilerplate/package.json
+++ b/packages/ext-angular-modern-boilerplate/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@angular-builders/custom-webpack": "^7.1.1",
     "@angular-builders/dev-server": "^7.1.1",
-    "@angular-devkit/build-angular": "~0.11.3",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@sencha/ext-angular-webpack-plugin": "~6.7.0",
     "html-webpack-plugin": "^3.2.0",
     "sass-loader":"^7.1.0",

--- a/packages/ext-angular-router/package.json
+++ b/packages/ext-angular-router/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@angular-builders/custom-webpack": "^7.0.0",
     "@angular-builders/dev-server": "^7.0.0",
-    "@angular-devkit/build-angular": "~0.11.3",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@sencha/ext-angular-webpack-plugin": "6.7.0",
     "html-webpack-plugin": "^3.2.0",
     "sass-loader":"^7.1.0",

--- a/packages/ext-angular-tests/package.json
+++ b/packages/ext-angular-tests/package.json
@@ -43,7 +43,7 @@
     "@angular-builders/custom-webpack": "^7.1.1",
     "@angular-builders/dev-server": "^7.1.1",
     "@sencha/ext-angular-webpack-plugin": "~6.7.0",
-    "@angular-devkit/build-angular": "~0.11.3",
+    "@angular-devkit/build-angular": "~0.12.1",
     "@angular/cli": "~7.1.0",
     "@angular/compiler-cli": "~7.1.2",
     "@angular/language-service": "~7.1.2",


### PR DESCRIPTION
@mgusmano @aniket91 Please review this version update to resolve security vulnerabilities noted when using ext-angular-gen. 

The actual security vulnerability has to do with the devkits dependency of an older version of webpack-dev-server. 